### PR TITLE
Create missing parent directories

### DIFF
--- a/src/xlsx_util.erl
+++ b/src/xlsx_util.erl
@@ -53,6 +53,7 @@ write(X, RelPath, Bytes) ->
 mktemp_dir(Prefix) ->
     Rand = integer_to_list(binary:decode_unsigned(crypto:strong_rand_bytes(8)), 36),
     TempPath = filename:basedir(user_cache, Prefix ++ Rand),
+    ok = filelib:ensure_dir(TempPath),
     Result = file:make_dir(TempPath),
     case Result of
         ok -> {ok, TempPath};


### PR DESCRIPTION
When the directory identified by `user_cache` does not exist, it needs to be created. `ensure_dir` does _just_ that. Note that `user_cache` respects `XDG_CACHE_HOME`.